### PR TITLE
Updated controllers for downloading videos to send file back as API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/YoutubeDownloaderModule/YoutubeDownloader.Service/executables/ffmpeg.exe
+/YoutubeDownloaderModule/YoutubeDownloader.Service/executables/yt-dlp.exe
+/.vs

--- a/YoutubeDownloaderModule/YoutubeDownloader.Service/Controllers/YoutubeDownloadController.cs
+++ b/YoutubeDownloaderModule/YoutubeDownloader.Service/Controllers/YoutubeDownloadController.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using System.IO.Compression;
 using YoutubeDLSharp;
 using YoutubeDLSharp.Metadata;

--- a/YoutubeDownloaderModule/YoutubeDownloader.Service/YoutubeDownloader.Service.csproj
+++ b/YoutubeDownloaderModule/YoutubeDownloader.Service/YoutubeDownloader.Service.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="YoutubeDLSharp" Version="1.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated controllers for downloading videos to send file back as API requests

1. Download single YouTube video and send back via API request.
2. Download multiple YouTube videos, convert to zip file and send back via API request.
3. Delete video files temporarily saved in server.